### PR TITLE
Ensure output directory exists before writing to the file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var fs = require('fs');
 var stripAnsi = require('strip-ansi');
+var mkdirp = require('mkdirp');
 
 var assets = {};
 var DEFAULT_OUTPUT_FILENAME = 'webpack-stats.json';
@@ -69,8 +70,8 @@ Plugin.prototype.apply = function(compiler) {
       };
 
       if (self.options.logTime === true) {
-          output.startTime = stats.startTime,
-          output.endTime = stats.endTime
+        output.startTime = stats.startTime;
+        output.endTime = stats.endTime;
       }
 
       self.writeOutput(compiler, output);
@@ -82,8 +83,9 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
   var outputDir = this.options.path || '.';
   var outputFilename = path.join(outputDir, this.options.filename || DEFAULT_OUTPUT_FILENAME);
   if (compiler.options.output.publicPath) {
-    contents.publicPath = compiler.options.output.publicPath
+    contents.publicPath = compiler.options.output.publicPath;
   }
+  mkdirp.sync(path.dirname(outputFilename));
   fs.writeFileSync(outputFilename, JSON.stringify(contents));
 };
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/owais/webpack-bundle-tracker/issues"
   },
   "dependencies": {
+    "mkdirp": "^0.5.1",
     "strip-ansi": "^2.0.1"
   }
 }


### PR DESCRIPTION
I used `mkdirp` to make sure the output directory exists before we try to write the file.

If the directory doesn't exist, the plugin will throw.

I also fixed some 3 lines with syntax errors. You probably should add a basic linter step to prevent these mishaps as long as you don't have any unit test coverage.
