### PR TITLE
fix webpack-stats.json override issue after miltuple build happened

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,12 @@ Plugin.prototype.apply = function(compiler) {
       }
 
       var chunks = {};
+      var outputDir = this.options.path || '.';
+      var outputFilename = path.join(outputDir, this.options.filename || DEFAULT_OUTPUT_FILENAME);
+      var obj = JSON.parse(fs.readFileSync(outputFilename, 'utf8'));
+      if (obj.status == 'done') {
+          chunks = obj.chunks;
+      }
       stats.compilation.chunks.map(function(chunk){
         var files = chunk.files.map(function(file){
           var F = {name: file};
@@ -62,7 +68,11 @@ Plugin.prototype.apply = function(compiler) {
           }
           return F;
         });
-        chunks[chunk.name] = files;
+        if (chunks[chunk.name]) {
+            chunks[chunk.name] =  chunks[chunk.name].concat(files)
+        } else {
+            chunks[chunk.name] = files;
+        }
       });
       var output = {
         status: 'done',


### PR DESCRIPTION
bug reproduction:

when you have a similar webpack.conf.js file like this:

```
......
var languages = {
    'en': null,
    'zh-cn': require('./zh-cn.json')
}

module.exports = Object.keys(languages).map(function(language) {
    return {
        name: language,
        entry: {
            entry: "aaa.js",
        },
        output: {
            path: path.resolve('./assets/bundles/'),
            filename: "[name]_[chunkhash]_" + language + ".js"
        },
        plugins: [
            new Clean(['./assets/bundles/']),
            new I18nPlugin(languages[language]),
            new BundleTracker({filename: './webpack-stats.json'})
        ]
.....
```

When build complete, you will have TWO output files in folder ./assets/bundles/ like this:

```
entry_a_[hash]_en.js
entry_a_[hash]_zh_cn.js
```

but in webpack-stats.json, only entry_a_[hash]_zh_cn.js was tracked.
