### PR TITLE
Add indent option, supply missing license field in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,6 @@ And in case `logTime` option is set to `true`, the output will look like,
 
 
 By default, the output JSON will not be indented. To increase readability, you can use the `indent`
-option to make the output legible. By default it is off. However you can pass in either a `number` or `string` to
-indicate the length or characters to use for indentation. You can also supply `true` to enable the default of a
-two space indentation.
+option to make the output legible. By default it is off. The value that is set here will be directly
+passed to the `space` parameter in `JSON.stringify`. More information can be found here:
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify

--- a/README.md
+++ b/README.md
@@ -91,3 +91,10 @@ And in case `logTime` option is set to `true`, the output will look like,
   "endTime":1440535326804
 }
 ```
+
+
+
+By default, the output JSON will not be indented. To increase readability, you can use the `indent`
+option to make the output legible. By default it is off. However you can pass in either a `number` or `string` to
+indicate the length or characters to use for indentation. You can also supply `true` to enable the default of a
+two space indentation.

--- a/index.js
+++ b/index.js
@@ -14,15 +14,6 @@ function Plugin(options) {
   if (this.options.logTime === undefined) {
     this.options.logTime = DEFAULT_LOG_TIME;
   }
-
-  if (typeof this.options.indent === 'undefined') { this.options.indent = null; }
-  if (this.options.indent !== null) {
-    if (typeof this.options.indent === 'boolean' && this.options.indent) {
-      this.options.indent = this.options.indent ? 2 : null;
-    } else if (typeof this.options.indent !== 'string' && typeof this.options.indent !== 'number') {
-      throw new Error('Indent should be of type boolean, number, or string, was ' + typeof this.options.indent);
-    }
-  }
 }
 
 Plugin.prototype.apply = function(compiler) {

--- a/index.js
+++ b/index.js
@@ -14,6 +14,15 @@ function Plugin(options) {
   if (this.options.logTime === undefined) {
     this.options.logTime = DEFAULT_LOG_TIME;
   }
+
+  if (typeof this.options.indent === 'undefined') { this.options.indent = null; }
+  if (this.options.indent !== null) {
+    if (typeof this.options.indent === 'boolean' && this.options.indent) {
+      this.options.indent = this.options.indent ? 2 : null;
+    } else if (typeof this.options.indent !== 'string' && typeof this.options.indent !== 'number') {
+      throw new Error('Indent should be of type boolean, number, or string, was ' + typeof this.options.indent);
+    }
+  }
 }
 
 Plugin.prototype.apply = function(compiler) {
@@ -86,7 +95,7 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
     contents.publicPath = compiler.options.output.publicPath;
   }
   mkdirp.sync(path.dirname(outputFilename));
-  fs.writeFileSync(outputFilename, JSON.stringify(contents));
+  fs.writeFileSync(outputFilename, JSON.stringify(contents, null, this.options.indent));
 };
 
 module.exports = Plugin;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "webpack-bundle-tracker",
   "version": "0.0.9",
   "description": "Spits out some stats about webpack compilation process to a file",
+  "license": "MIT",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This is a PR to allow an indentation to be specified to help with the webpack-stats.json formatting. This is backwards compatible and defaults to null. This simply just passes the option value to JSON.stringify. I also got a warning from npm about a missing license field in package.json, so I just added it to match the LICENSE file.
