### PR TITLE
Refs #4 - Added option 'includePath'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ And errors will look like,
 `ErrorMessage` shows the line and column that caused the error.
 
 
+#### Options
 
-And in case `logTime` option is set to `true`, the output will look like,
+##### logTime
+
+If the `logTime` option is set to `true`, the output will look like,
 ```
 {
   "status":"done",
@@ -92,9 +95,24 @@ And in case `logTime` option is set to `true`, the output will look like,
 }
 ```
 
-
+##### indent
 
 By default, the output JSON will not be indented. To increase readability, you can use the `indent`
 option to make the output legible. By default it is off. The value that is set here will be directly
 passed to the `space` parameter in `JSON.stringify`. More information can be found here:
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+
+##### includePath
+
+If the `includePath` option is set to `false`, the output will look like,
+```
+{
+  "status":"done",
+  "chunks":{
+   "app":[{
+      "name":"app-0828904584990b611fb8.js",
+      "publicPath":"http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
+    }]
+  },
+}
+```

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ function Plugin(options) {
   if (this.options.logTime === undefined) {
     this.options.logTime = DEFAULT_LOG_TIME;
   }
+  if (this.options.includePath === undefined) {
+    this.options.includePath = true;
+  }
 }
 
 Plugin.prototype.apply = function(compiler) {
@@ -57,7 +60,7 @@ Plugin.prototype.apply = function(compiler) {
           if (compiler.options.output.publicPath) {
             F.publicPath= compiler.options.output.publicPath + file;
           }
-          if (compiler.options.output.path) {
+          if (self.options.includePath && compiler.options.output.path) {
             F.path = path.join(compiler.options.output.path, file);
           }
           return F;


### PR DESCRIPTION
I've added this option so that the full path does not have to be output in the `webpack-stats.json`.

This is useful, as stated in #4, if you want to commit `webpack-stats.json` to source control.

As far as I can tell removing `path` has no consequences for https://github.com/owais/django-webpack-loader
