### PR TITLE
Merge new chunks with chunks in the existing stats file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
     contents.publicPath = compiler.options.output.publicPath;
   }
   mkdirp.sync(path.dirname(outputFilename));
-  var existingStats = {};
+  var existingStats = '{}';
   try {
     existingStats = fs.readFileSync(outputFilename);
   } catch (error) {

--- a/index.js
+++ b/index.js
@@ -86,16 +86,16 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
     contents.publicPath = compiler.options.output.publicPath;
   }
   mkdirp.sync(path.dirname(outputFilename));
-  var existingStats = '{}';
+  var existingStats = {};
   try {
     existingStats = fs.readFileSync(outputFilename);
+    existingStats = JSON.parse(existingStats);
   } catch (error) {
     if (error.code !== 'ENOENT') {
       // If the error isn't caused by a non-existent file, throw it.
       throw error;
     }
   }
-  existingStats = JSON.parse(existingStats);
   if (existingStats.status === 'done') {
     // Only append to existing chunks if the previous stats file status is 'done'.
     var mergedChunks = Object.assign(existingStats.chunks, contents.chunks);

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function Plugin(options) {
   if (this.options.logTime === undefined) {
     this.options.logTime = DEFAULT_LOG_TIME;
   }
+  this.options.append = options.append || false;
 }
 
 Plugin.prototype.apply = function(compiler) {
@@ -86,7 +87,11 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
     contents.publicPath = compiler.options.output.publicPath;
   }
   mkdirp.sync(path.dirname(outputFilename));
-  fs.writeFileSync(outputFilename, JSON.stringify(contents, null, this.options.indent));
+  if (this.options.append) {
+    fs.appendFileSync(outputFilename, JSON.stringify(contents, null, this.options.indent));
+  } else {
+    fs.writeFileSync(outputFilename, JSON.stringify(contents, null, this.options.indent));
+  }
 };
 
 module.exports = Plugin;


### PR DESCRIPTION
I ran into the issue of using multi-compiler mode in webpack, and in such a case, I'd want to be able to use the same webpack-stats file. Currently, the bundle tracker plugin will overwrite whatever was previously in the stats file.
