### PR TITLE
Added support for assets into the bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,26 +22,28 @@ module.exports = {
         context: __dirname,
     entry: {
       app: ['./app'],
-      exported_assets: "./assets/exported-assets.js"
+      exported_assets: "./assets/exported_assets.js"
     },
-    
+
     output: {
         path: require("path").resolve('./assets/bundles/'),
         filename: "[name]-[hash].js",
         publicPath: 'http://localhost:3000/assets/bundles/',
     },
-    
+
     plugins: [
       new BundleTracker({path: __dirname, filename: './assets/webpack-stats.json'})
     ]
 }
 ```
 
-`./assets/exported-assets.js` will look like,
+`./assets/exported_assets.js` will look like,
 
 ```javascript
 require("./assets/my_asset.png");
 ```
+
+Keep in mind that the filename and the identifier should be the same as the identifier will be exposed in the webstats-file as a key. (filename: exported_assets.js; identifier: exported_assets)
 
 `./assets/webpack-stats.json` will look like,
 
@@ -61,7 +63,7 @@ require("./assets/my_asset.png");
         "path":"/home/user/project-root/assets/bundles/e9f0767cc79a227912c41ad07b09d91f.png"
       }
     }
-  }  
+  }
 }
 ```
 
@@ -81,7 +83,7 @@ And errors will look like,
 {
   "status": "error",
   "file": "/path/to/file/that/caused/the/error",
-  "error": "ErrorName", 
+  "error": "ErrorName",
   "message": "ErrorMessage"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ var BundleTracker  = require('webpack-bundle-tracker');
 module.exports = {
         context: __dirname,
     entry: {
-      app: ['./app']
+      app: ['./app'],
+      exported_assets: "./assets/exported-assets.js"
     },
     
     output: {
@@ -36,6 +37,12 @@ module.exports = {
 }
 ```
 
+`./assets/exported-assets.js` will look like,
+
+```javascript
+require("./assets/my_asset.png");
+```
+
 `./assets/webpack-stats.json` will look like,
 
 ```json
@@ -46,8 +53,15 @@ module.exports = {
       "name":"app-0828904584990b611fb8.js",
       "publicPath":"http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
       "path":"/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
-    }]
-  }
+    }],
+    "exported_assets": {
+      "./assets/my_asset.png":{
+        "name":"e9f0767cc79a227912c41ad07b09d91f.png",
+        "publicPath":"http://localhost:3000/assets/bundles/e9f0767cc79a227912c41ad07b09d91f.png",
+        "path":"/home/user/project-root/assets/bundles/e9f0767cc79a227912c41ad07b09d91f.png"
+      }
+    }
+  }  
 }
 ```
 
@@ -85,7 +99,14 @@ And in case `logTime` option is set to `true`, the output will look like,
       "name":"app-0828904584990b611fb8.js",
       "publicPath":"http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
       "path":"/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
-    }]
+    }],
+    "exported_assets": {
+      "./assets/my_asset.png":{
+        "name":"e9f0767cc79a227912c41ad07b09d91f.png",
+        "publicPath":"http://localhost:3000/assets/bundles/e9f0767cc79a227912c41ad07b09d91f.png",
+        "path":"/home/user/project-root/assets/bundles/e9f0767cc79a227912c41ad07b09d91f.png"
+      }
+    }
   },
   "startTime":1440535322138,
   "endTime":1440535326804

--- a/index.js
+++ b/index.js
@@ -21,6 +21,30 @@ function Plugin(options) {
   }
 }
 
+var buildAsset = function(compiler, chunk, fileName) {
+  var asset = {name: fileName};
+  if (compiler.options.output.publicPath) {
+    asset.publicPath = compiler.options.output.publicPath + fileName;
+  }
+  if (compiler.options.output.path) {
+    asset.path = path.join(compiler.options.output.path, fileName);
+  }
+};
+
+var buildChunk = function(compiler, chunk) {
+  var files = chunk.files.map(function(file){
+    var F = {name: file};
+    if (compiler.options.output.publicPath) {
+      F.publicPath= compiler.options.output.publicPath + file;
+    }
+    if (compiler.options.output.path) {
+      F.path = path.join(compiler.options.output.path, file);
+    }
+    return F;
+  });
+
+};
+
 Plugin.prototype.apply = function(compiler) {
     var self = this;
 
@@ -63,29 +87,11 @@ Plugin.prototype.apply = function(compiler) {
           chunk.modules.map(function(module){
             var fileName = Object.keys(module.assets)[0];
             if (fileName !== undefined && fileName.endsWith(self.options.assetsIdentifier + ".js") !== true) {
-              var asset = {name: fileName};
-              if (compiler.options.output.publicPath) {
-                asset.publicPath = compiler.options.output.publicPath + fileName;
-              }
-              if (compiler.options.output.path) {
-                asset.path = path.join(compiler.options.output.path, fileName);
-              }
-
-              assets[module.rawRequest] = asset;
+              assets[module.rawRequest] = buildAsset(compiler, chunk, fileName);
             }
           });
         } else {
-          var files = chunk.files.map(function(file){
-            var F = {name: file};
-            if (compiler.options.output.publicPath) {
-              F.publicPath= compiler.options.output.publicPath + file;
-            }
-            if (compiler.options.output.path) {
-              F.path = path.join(compiler.options.output.path, file);
-            }
-            return F;
-          });
-          chunks[chunk.name] = files;
+          chunks[chunk.name] = buildChunk(compiler, chunk);
         }
       });
 
@@ -121,5 +127,3 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
 };
 
 module.exports = Plugin;
-
-

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ var buildAsset = function(compiler, chunk, fileName) {
   if (compiler.options.output.path) {
     asset.path = path.join(compiler.options.output.path, fileName);
   }
+  return asset;
 };
 
 var buildChunk = function(compiler, chunk) {
@@ -42,7 +43,7 @@ var buildChunk = function(compiler, chunk) {
     }
     return F;
   });
-
+  return files;
 };
 
 Plugin.prototype.apply = function(compiler) {

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ Plugin.prototype.apply = function(compiler) {
       var chunks = {};
       var assets = {};
       stats.compilation.chunks.map(function(chunk) {
-        if (chunk.name == self.){
+        if (chunk.name == self.options.assetsIdentifier){
           // each module represents a list of assets with only one item or the file itself/ improper loaded assets
           chunk.modules.map(function(module){
             var fileName = Object.keys(module.assets)[0];
@@ -88,11 +88,12 @@ Plugin.prototype.apply = function(compiler) {
           chunks[chunk.name] = files;
         }
       });
+
       var output = {
         status: 'done',
-        chunks: chunks,
-        self.options.assetsIdentifier: assets
+        chunks: chunks
       };
+      output[self.options.assetsIdentifier] = assets;
 
       if (self.options.logTime === true) {
         output.startTime = stats.startTime;
@@ -120,4 +121,5 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
 };
 
 module.exports = Plugin;
+
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var DEFAULT_ASSETS_IDENTIFIER = 'exported_assets';
 var DEFAULT_LOG_TIME = false;
 
 
-function Plugin(options, assets_file) {
+function Plugin(options) {
   this.contents = {};
   this.options = options || {};
   this.options.filename = this.options.filename || DEFAULT_OUTPUT_FILENAME;

--- a/index.js
+++ b/index.js
@@ -7,13 +7,15 @@ var mkdirp = require('mkdirp');
 
 var assets = {};
 var DEFAULT_OUTPUT_FILENAME = 'webpack-stats.json';
+var DEFAULT_ASSETS_IDENTIFIER = 'exported_assets';
 var DEFAULT_LOG_TIME = false;
 
 
-function Plugin(options) {
+function Plugin(options, assets_file) {
   this.contents = {};
   this.options = options || {};
   this.options.filename = this.options.filename || DEFAULT_OUTPUT_FILENAME;
+  this.options.assetsIdentifier = this.options.assetsIdentifier || DEFAULT_ASSETS_IDENTIFIER;
   if (this.options.logTime === undefined) {
     this.options.logTime = DEFAULT_LOG_TIME;
   }
@@ -56,12 +58,12 @@ Plugin.prototype.apply = function(compiler) {
       var chunks = {};
       var assets = {};
       stats.compilation.chunks.map(function(chunk) {
-        if (chunk.name == "exported_assets"){
+        if (chunk.name == self.){
           // each module represents a list of assets with only one item or the file itself/ improper loaded assets
           chunk.modules.map(function(module){
             var fileName = Object.keys(module.assets)[0];
-            if (fileName !== undefined && fileName.endsWith("exported-assets.js") !== true) {
-              var asset = {};
+            if (fileName !== undefined && fileName.endsWith(self.options.assetsIdentifier + ".js") !== true) {
+              var asset = {name: fileName};
               if (compiler.options.output.publicPath) {
                 asset.publicPath = compiler.options.output.publicPath + fileName;
               }
@@ -89,7 +91,7 @@ Plugin.prototype.apply = function(compiler) {
       var output = {
         status: 'done',
         chunks: chunks,
-        exported_assets: assets
+        self.options.assetsIdentifier: assets
       };
 
       if (self.options.logTime === true) {


### PR DESCRIPTION
Basically, anything that might be required to be linked as assets may
be done through the exported-assets.js with require, making sure
that it is properly loaded webpack.config.js and that every file type
has a proper loader for it.

#15