### PR TITLE
Correctly deep extend the stats file contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var stripAnsi = require('strip-ansi');
 var mkdirp = require('mkdirp');
+var extend = require('deep-extend');
 
 var assets = {};
 var DEFAULT_OUTPUT_FILENAME = 'webpack-stats.json';
@@ -88,7 +89,7 @@ Plugin.prototype.writeOutput = function(compiler, contents) {
   }
   mkdirp.sync(path.dirname(outputFilename));
 
-  this.contents = Object.assign(this.contents, contents);
+  this.contents = extend(this.contents, contents);
   fs.writeFileSync(
     outputFilename,
     JSON.stringify(this.contents, null, this.options.indent)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "url": "https://github.com/owais/webpack-bundle-tracker/issues"
   },
   "dependencies": {
+    "deep-extend": "^0.4.1",
     "mkdirp": "^0.5.1",
     "strip-ansi": "^2.0.1"
   }


### PR DESCRIPTION
`Object.assign` only does a shallow extends, so the key that really mattered (`chunks`) was still being overwritten on each run.

`Object.assign` is working for webpack-assets-manifest because they're having a single level stats files.