### PR TITLE
Support webpack 2 code splitting

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,8 @@ Plugin.prototype.apply = function(compiler) {
           }
           return F;
         });
-        chunks[chunk.name] = files;
+        var chunkName = chunk.name || '_dynamic';
+        chunks[chunkName] = [].concat(chunks[chunkName] || [], files);
       });
       var output = {
         status: 'done',


### PR DESCRIPTION
JS that was split up in multiple files was not added correctly to stats.json.
0-md5.js would be overwritten with 1-md5.js if there is a dynamic bundle.

This code fixes that.