### PR TITLE
Fixes #22 -- Adds trackAssets option to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ and the output will look like:
         "path":"/home/user/project-root/assets/bundles/app-eef39b47d0d3ee.css"
       },
       {
-        "name":912ec66d7572ff821749319396470bde.svg",
+        "name":"912ec66d7572ff821749319396470bde.svg",
         "publicPath":"/static/bundles/912ec66d7572ff821749319396470bde.svg",
         "path":"/Users/ryanar/Code/rit-das-pdp/pd/static/bundles/912ec66d7572ff821749319396470bde.svg"
       }

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ And in case `logTime` option is set to `true`, the output will look like,
 
 To track all assets output by webpack, pass the `trackAssets: true` option to the plugin:
 
-javascript
+```javascript
 var BundleTracker  = require('webpack-bundle-tracker');
 module.exports = {
-        context: __dirname,
+    context: __dirname,
     entry: {
       app: ['./app']
     },

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ and the output will look like:
       {
         "name":"912ec66d7572ff821749319396470bde.svg",
         "publicPath":"/static/bundles/912ec66d7572ff821749319396470bde.svg",
-        "path":"/Users/ryanar/Code/rit-das-pdp/pd/static/bundles/912ec66d7572ff821749319396470bde.svg"
+        "path":"/home/user/project-root/assets/bundles/912ec66d7572ff821749319396470bde.svg"
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ module.exports = {
     entry: {
       app: ['./app']
     },
-    
+
     output: {
         path: require("path").resolve('./assets/bundles/'),
         filename: "[name]-[hash].js",
         publicPath: 'http://localhost:3000/assets/bundles/',
     },
-    
+
     plugins: [
       new BundleTracker({path: __dirname, filename: './assets/webpack-stats.json'})
     ]
@@ -42,7 +42,7 @@ module.exports = {
 {
   "status":"done",
   "chunks":{
-   "app":[{
+    "app":[{
       "name":"app-0828904584990b611fb8.js",
       "publicPath":"http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
       "path":"/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
@@ -67,7 +67,7 @@ And errors will look like,
 {
   "status": "error",
   "file": "/path/to/file/that/caused/the/error",
-  "error": "ErrorName", 
+  "error": "ErrorName",
   "message": "ErrorMessage"
 }
 ```
@@ -92,7 +92,73 @@ And in case `logTime` option is set to `true`, the output will look like,
 }
 ```
 
+To track all assets output by webpack, pass the `trackAssets: true` option to the plugin:
 
+javascript
+var BundleTracker  = require('webpack-bundle-tracker');
+module.exports = {
+        context: __dirname,
+    entry: {
+      app: ['./app']
+    },
+
+    output: {
+        path: require("path").resolve('./assets/bundles/'),
+        filename: "[name]-[hash].js",
+        publicPath: 'http://localhost:3000/assets/bundles/',
+    },
+
+    plugins: [
+      new BundleTracker({
+        path: __dirname,
+        filename: './assets/webpack-stats.json',
+        trackAssets: true,
+        assetsChunkName: 'assets' // defaults to this
+      })
+    ]
+}
+```
+
+and the output will look like:
+
+```json
+{
+  "status":"done",
+  "chunks":{
+    "app":[
+      {
+        "name":"app-0828904584990b611fb8.js",
+        "publicPath":"http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
+        "path":"/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
+      }
+    ],
+    "assets":[
+      {
+        "name":"app-0828904584990b611fb8.js",
+        "publicPath":"http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
+        "path":"/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
+      },
+      {
+        "name":"app-0828904584990b611fb8.js.gz",
+        "publicPath":"http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js.gz",
+        "path":"/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js.gz"
+      },
+      {
+        "name":"app-eef39b47d0d3ee.css",
+        "publicPath":"http://localhost:3000/assets/bundles/app-eef39b47d0d3ee.css",
+        "path":"/home/user/project-root/assets/bundles/app-eef39b47d0d3ee.css"
+      },
+      {
+        "name":912ec66d7572ff821749319396470bde.svg",
+        "publicPath":"/static/bundles/912ec66d7572ff821749319396470bde.svg",
+        "path":"/Users/ryanar/Code/rit-das-pdp/pd/static/bundles/912ec66d7572ff821749319396470bde.svg"
+      }
+    ]
+  }
+}
+```
+
+This option allows all assets to be tracked and accessed but can result in much larger `.json` files.
 
 By default, the output JSON will not be indented. To increase readability, you can use the `indent`
 option to make the output legible. By default it is off. The value that is set here will be directly

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ Plugin.prototype.apply = function(compiler) {
         chunks[chunk.name] = files;
       });
 
-      if (this.options.trackAssets) {
+      if (self.options.trackAssets === true) {
         var assets = [];
         Object.keys(stats.compilation.assets).map(function(asset){
           var F = {name: asset};

--- a/index.js
+++ b/index.js
@@ -7,12 +7,15 @@ var extend = require('deep-extend');
 var assets = {};
 var DEFAULT_OUTPUT_FILENAME = 'webpack-stats.json';
 var DEFAULT_LOG_TIME = false;
+var DEFAULT_ASSET_CHUNK_NAME = 'assets';
 
 
 function Plugin(options) {
   this.contents = {};
   this.options = options || {};
   this.options.filename = this.options.filename || DEFAULT_OUTPUT_FILENAME;
+  this.options.trackAssets = this.options.trackAssets || false;
+  this.options.assetsChunkName = this.options.assetsChunkName || DEFAULT_ASSET_CHUNK_NAME;
   if (this.options.logTime === undefined) {
     this.options.logTime = DEFAULT_LOG_TIME;
   }
@@ -57,7 +60,7 @@ Plugin.prototype.apply = function(compiler) {
         var files = chunk.files.map(function(file){
           var F = {name: file};
           if (compiler.options.output.publicPath) {
-            F.publicPath= compiler.options.output.publicPath + file;
+            F.publicPath = compiler.options.output.publicPath + file;
           }
           if (compiler.options.output.path) {
             F.path = path.join(compiler.options.output.path, file);
@@ -66,6 +69,22 @@ Plugin.prototype.apply = function(compiler) {
         });
         chunks[chunk.name] = files;
       });
+
+      if (this.options.trackAssets) {
+        var assets = [];
+        Object.keys(stats.compilation.assets).map(function(asset){
+          var F = {name: asset};
+          if (compiler.options.output.publicPath) {
+            F.publicPath= compiler.options.output.publicPath + asset;
+          }
+          if (compiler.options.output.path) {
+            F.path = path.join(compiler.options.output.path, asset);
+          }
+          assets.push(F);
+        });
+        chunks[DEFAULT_ASSET_CHUNK_NAME] = assets;
+      }
+
       var output = {
         status: 'done',
         chunks: chunks


### PR DESCRIPTION
Asset tracking is off by default, by passing the `trackAssets` boolean to the
plugin options, all assets output by webpack will be added as a chunk with the
default chunk name `assets` to the `webpack-stats.json` file.

This enables rendering of files that are separately processed like gzipped js
and css from `compress-webpack-plugin`, fixing #22 .