### PR TITLE
Add publicPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ npm install --save-dev webpack-bundle-tracker
 ```javascript
 var BundleTracker  = require('webpack-bundle-tracker');
 module.exports = {
-        context: __dirname,
+    context: __dirname,
     entry: {
       app: ['./app']
     },
-    
+
     output: {
         path: require("path").resolve('./assets/bundles/'),
         filename: "[name]-[hash].js",
         publicPath: 'http://localhost:3000/assets/bundles/',
     },
-    
+
     plugins: [
       new BundleTracker({path: __dirname, filename: './assets/webpack-stats.json'})
     ]
@@ -67,7 +67,7 @@ And errors will look like,
 {
   "status": "error",
   "file": "/path/to/file/that/caused/the/error",
-  "error": "ErrorName", 
+  "error": "ErrorName",
   "message": "ErrorMessage"
 }
 ```
@@ -98,3 +98,12 @@ By default, the output JSON will not be indented. To increase readability, you c
 option to make the output legible. By default it is off. The value that is set here will be directly
 passed to the `space` parameter in `JSON.stringify`. More information can be found here:
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+
+<br>
+
+#### Bundle Tracker Options
+
+* `filename` - Name of the bundle tracker JSON file.
+* `logTime` - Optional boolean property to output `startTime` and `endTime` in bundle tracker file.
+* `path` - Optional bundle tracker output path.
+* `publicPath` - Optional property to override `output.publicPath`.

--- a/index.js
+++ b/index.js
@@ -58,8 +58,9 @@ Plugin.prototype.apply = function(compiler) {
       stats.compilation.chunks.map(function(chunk){
         var files = chunk.files.map(function(file){
           var F = {name: file};
-          if (compiler.options.output.publicPath) {
-            F.publicPath= compiler.options.output.publicPath + file;
+          var publicPath = self.options.publicPath || compiler.options.output.publicPath;
+          if (publicPath) {
+            F.publicPath = publicPath + file;
           }
           if (compiler.options.output.path) {
             F.path = path.join(compiler.options.output.path, file);
@@ -86,8 +87,9 @@ Plugin.prototype.apply = function(compiler) {
 Plugin.prototype.writeOutput = function(compiler, contents) {
   var outputDir = this.options.path || '.';
   var outputFilename = path.join(outputDir, this.options.filename || DEFAULT_OUTPUT_FILENAME);
-  if (compiler.options.output.publicPath) {
-    contents.publicPath = compiler.options.output.publicPath;
+  var publicPath = this.options.publicPath || compiler.options.output.publicPath;
+  if (publicPath) {
+    contents.publicPath = publicPath;
   }
   mkdirp.sync(path.dirname(outputFilename));
 


### PR DESCRIPTION
@owais Hi, I have a case where I need to generate different JSON files for different environments.  And so the `publicPath` they reference are different, but assets are all same.

I've added `publicPath` as an option to the plugin to look at that first before looking at `output.publicPath`.

```javascript
plugins: [
  new BundleTracker({
    filename: './webpack-stats-staging.json',
    publicPath: '/',
  }),
  new BundleTracker({
    filename: './webpack-stats-live.json',
    publicPath: 'https://nginx-static-server/',
  }),
]
```