### PR TITLE
update deep-extend to v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/owais/webpack-bundle-tracker/issues"
   },
   "dependencies": {
-    "deep-extend": "^0.4.1",
+    "deep-extend": "^0.5.1",
     "mkdirp": "^0.5.1",
     "strip-ansi": "^2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "url": "https://github.com/owais/webpack-bundle-tracker/issues"
   },
   "dependencies": {
-    "deep-extend": "^0.5.1",
+    "deep-extend": "^0.6.0",
     "mkdirp": "^0.5.1",
-    "strip-ansi": "^2.0.1"
+    "strip-ansi": "^4.0.0"
   }
 }


### PR DESCRIPTION
Since the currently used version v0.4.1 there have been no breaking changes, so updating should be fine. The latest version also includes a fix for the (low severity) security advisory CWE-471 (https://nodesecurity.io/advisories/612), which I noticed via the new ```npm audit``` command and which prompted this PR.

strip-ansi could also be updated (introducing a lower Node version limit of 4, which I think wouldn't be a problem), but that doesn't fix an advisory, so I felt that should be done separately. I can include that update as well if you want.