### PR TITLE
Fix a reference error

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ Plugin.prototype.apply = function(compiler) {
       compiler.hooks.compile.tap(plugin, compile);
       compiler.hooks.done.tap(plugin, done);
     } else {
-      compiler.plugin('compilation', compilation);
+      compiler.plugin('compilation', _compilation);
       compiler.plugin('compile', compile);
       compiler.plugin('done', done);
     }


### PR DESCRIPTION
This PR fixes a `ReferenceError` that occurs when webpack-bundle-tracker used with Webpack 3.