### PR TITLE
Update deep-extend to 0.6.0 to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/owais/webpack-bundle-tracker/issues"
   },
   "dependencies": {
-    "deep-extend": "^0.4.1",
+    "deep-extend": "^0.6.0",
     "mkdirp": "^0.5.1",
     "strip-ansi": "^2.0.1"
   }


### PR DESCRIPTION
deep-extend before 0.5.1 has a vulnerability listed here: https://www.npmjs.com/advisories/612/versions

I would like to update to 0.6.0. Should not cause any issues.