### PR TITLE
feature: dumping stats about each entrypoint and the chunks it uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,20 @@ module.exports = {
   },
   "entryPoints": {
     "main": [
-      {
+      [
+        {
         "name": "app-0828904584990b611fb8.js",
         "publicPath": "http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
         "path": "/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
-      },
-      {
+        }
+      ],
+      [
+        {
         "name": "runtime-58e2b6c82f0f9e50524c.js",
         "publicPath": "http://localhost:3000/assets/bundles/runtime-58e2b6c82f0f9e50524c.js",
         "path": "/home/user/project-root/assets/bundles/runtime-58e2b6c82f0f9e50524c.js"
-      }
+        }
+      ]
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -40,13 +40,36 @@ module.exports = {
 
 ```json
 {
-  "status":"done",
-  "chunks":{
-   "app":[{
-      "name":"app-0828904584990b611fb8.js",
-      "publicPath":"http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
-      "path":"/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
-    }]
+  "status": "done",
+  "chunks": {
+    "app": [
+      {
+        "name": "app-0828904584990b611fb8.js",
+        "publicPath": "http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
+        "path": "/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
+      }
+    ],
+    "runtime": [
+      {
+        "name": "runtime-58e2b6c82f0f9e50524c.js",
+        "publicPath": "http://localhost:3000/assets/bundles/runtime-58e2b6c82f0f9e50524c.js",
+        "path": "/home/user/project-root/assets/bundles/runtime-58e2b6c82f0f9e50524c.js"
+      }
+    ]
+  },
+  "entryPoints": {
+    "main": [
+      {
+        "name": "app-0828904584990b611fb8.js",
+        "publicPath": "http://localhost:3000/assets/bundles/app-0828904584990b611fb8.js",
+        "path": "/home/user/project-root/assets/bundles/app-0828904584990b611fb8.js"
+      },
+      {
+        "name": "runtime-58e2b6c82f0f9e50524c.js",
+        "publicPath": "http://localhost:3000/assets/bundles/runtime-58e2b6c82f0f9e50524c.js",
+        "path": "/home/user/project-root/assets/bundles/runtime-58e2b6c82f0f9e50524c.js"
+      }
+    ]
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -77,31 +77,33 @@ Plugin.prototype.apply = function(compiler) {
         chunks[chunk.name] = files;
       });
 
-      var entryPoints = {};
-      stats.compilation.entrypoints.forEach(function(value, entrypoint) {
-      entrypointsChunks = value.chunks.map(function(chunk) {
-        var files = chunk.files.map(function(file){
-          var F = {name: file};
-          var publicPath = self.options.publicPath || compiler.options.output.publicPath;
-          if (publicPath) {
-            F.publicPath = publicPath + file;
-          }
-          if (compiler.options.output.path) {
-            F.path = path.join(compiler.options.output.path, file);
-          }
-          return F; 
-        });
-        return files;
-      });
-      entryPoints[entrypoint] = entrypointsChunks;
-    });
-
       var output = {
         status: 'done',
-        chunks: chunks,
-        entryPoints: entryPoints
+        chunks: chunks
       };
 
+      if (stats.compilation.entrypoints){
+        var entryPoints = {};
+        stats.compilation.entrypoints.forEach(function(value, entrypoint) {
+        entrypointsChunks = value.chunks.map(function(chunk) {
+          var files = chunk.files.map(function(file){
+            var F = {name: file};
+            var publicPath = self.options.publicPath || compiler.options.output.publicPath;
+            if (publicPath) {
+              F.publicPath = publicPath + file;
+            }
+            if (compiler.options.output.path) {
+              F.path = path.join(compiler.options.output.path, file);
+            }
+            return F; 
+            });
+          return files;
+          });
+        entryPoints[entrypoint] = entrypointsChunks;
+        });
+      output['entryPoints'] = entryPoints
+      }
+      
       if (self.options.logTime === true) {
         output.startTime = stats.startTime;
         output.endTime = stats.endTime;

--- a/index.js
+++ b/index.js
@@ -61,6 +61,8 @@ Plugin.prototype.apply = function(compiler) {
         return;
       }
 
+      production = stats.compilation.options.mode === "production";
+
       var chunks = {};
       stats.compilation.chunks.map(function(chunk){
         var files = chunk.files.map(function(file){
@@ -76,9 +78,34 @@ Plugin.prototype.apply = function(compiler) {
         });
         chunks[chunk.name] = files;
       });
+
+      var entryPoints = {};
+      stats.compilation.entrypoints.forEach(function(value, entrypoint) {
+      entrypointsChunks = value.chunks.map(function(chunk) {
+        var renderedHashToAppend = '-' + chunk.renderedHash;
+        var chunkName = chunk.name;
+        if (production) {
+          chunkName += renderedHashToAppend;
+        }
+        chunkName += '.js';
+        var C = { name: chunkName };
+        var publicPath =
+          self.options.publicPath || compiler.options.output.publicPath;
+        if (publicPath) {
+          C.publicPath = publicPath + chunkName;
+        }
+        if (compiler.options.output.path) {
+          C.path = path.join(compiler.options.output.path, chunkName);
+        }
+        return C;
+      });
+      entryPoints[entrypoint] = entrypointsChunks;
+    });
+
       var output = {
         status: 'done',
-        chunks: chunks
+        chunks: chunks,
+        entryPoints: entryPoints
       };
 
       if (self.options.logTime === true) {

--- a/index.js
+++ b/index.js
@@ -61,8 +61,6 @@ Plugin.prototype.apply = function(compiler) {
         return;
       }
 
-      production = stats.compilation.options.mode === "production";
-
       var chunks = {};
       stats.compilation.chunks.map(function(chunk){
         var files = chunk.files.map(function(file){
@@ -82,22 +80,18 @@ Plugin.prototype.apply = function(compiler) {
       var entryPoints = {};
       stats.compilation.entrypoints.forEach(function(value, entrypoint) {
       entrypointsChunks = value.chunks.map(function(chunk) {
-        var renderedHashToAppend = '-' + chunk.renderedHash;
-        var chunkName = chunk.name;
-        if (production) {
-          chunkName += renderedHashToAppend;
-        }
-        chunkName += '.js';
-        var C = { name: chunkName };
-        var publicPath =
-          self.options.publicPath || compiler.options.output.publicPath;
-        if (publicPath) {
-          C.publicPath = publicPath + chunkName;
-        }
-        if (compiler.options.output.path) {
-          C.path = path.join(compiler.options.output.path, chunkName);
-        }
-        return C;
+        var files = chunk.files.map(function(file){
+          var F = {name: file};
+          var publicPath = self.options.publicPath || compiler.options.output.publicPath;
+          if (publicPath) {
+            F.publicPath = publicPath + file;
+          }
+          if (compiler.options.output.path) {
+            F.path = path.join(compiler.options.output.path, file);
+          }
+          return F; 
+        });
+        return files;
       });
       entryPoints[entrypoint] = entrypointsChunks;
     });


### PR DESCRIPTION
This makes it possible for django-webpack-loader or any similar packages to automatically include all assets for a particular endpoint, making it possible to have webpack split vendor code into small chunks and ship the least amount possible of code.

The change is backwards compatible as it only adds the key "entryPoints" to the json stats file.

The corresponding PR for django-webpack-loader (that makes use of this new key) can be found [here](https://github.com/owais/django-webpack-loader/pull/182) 