### PR TITLE
fix: Make each plugin option optional in type definition

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -12,12 +12,12 @@ declare namespace BundleTrackerPlugin {
      * Output directory of the bundle tracker JSON file
      * Default: `'.'`
      */
-    path: string;
+    path?: string;
     /**
      * Name of the bundle tracker JSON file.
      * Default: `'webpack-stats.json'`
      */
-    filename: string;
+    filename?: string;
     /**
      * Property to override default `output.publicPath` from Webpack config file.
      */
@@ -38,13 +38,14 @@ declare namespace BundleTrackerPlugin {
     indent?: number;
     /**
      * Enable subresources integrity
+     * Default: `false`
      */
-    integrity: boolean;
+    integrity?: boolean;
     /**
      * Set subresources integrity hashes
      * Default: `[ 'sha256', 'sha384', 'sha512' ]`
      */
-    integrityHashes: string[];
+    integrityHashes?: string[];
   }
   interface Contents {
     /**


### PR DESCRIPTION
For the type definition of `options`, options itself can be omitted _as well as_ each individual option key.

For example, this should be valid, but TypeScript doesn't think so:

```typescript
new BundleTracker({ filename: 'webpack-stats.json' }),
```

![Screen Shot 2020-01-03 at 2 51 48 PM](https://user-images.githubusercontent.com/1441807/71753811-9325dd80-2e38-11ea-998c-02bc7aa2729f.png)

This PR updates the type definition to make each option key optional.