### PR TITLE
Document missing option + fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,6 @@ passed to the `space` parameter in `JSON.stringify`. More information can be fou
 | `logTime`         | `{Boolean}` | `false`                          | Output `startTime` and `endTime` properties in bundle tracker JSON file.                                                        |
 | `integrity`       | `{Boolean}` | `false`                          | Output `integrity` property for each asset entry.                                                                               |
 | `integrityHashes` | `{Array}`   | `['sha256', 'sha384', 'sha512']` | Cryptographic hash functions used to compute integrity for each asset.                                                          |
+| `indent` | `{Integer}`   | `?` | Format resulting JSON file for better readability.                                                          |
+
+`?` denotes the option is initially not set.

--- a/README.md
+++ b/README.md
@@ -177,13 +177,11 @@ passed to the `space` parameter in `JSON.stringify`. More information can be fou
 
 | Name              | Type        | Default                          | Description                                                                                                                     |
 | ----------------- | ----------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `path`            | `{String}`  | `'.'`                            | Output directory of bundle tracker JSON file .                                                                                  |
+| `path`            | `{String}`  | `'.'`                            | Output directory of bundle tracker JSON file.                                                                                   |
 | `filename`        | `{String}`  | `'webpack-stats.json'`           | Name of the bundle tracker JSON file.                                                                                           |
-| `publicPath`      | `{String}`  | `?`                              | Override `output.publicPath` from Webpack config.                                                                               |
-| `relativePath`    | `{Boolean}` | `?`                              | Show relative path instead of absolute path for bundles in JSON Tracker file. Path are relative from path of JSON Tracker file. |
+| `publicPath`      | `{String}`  | (ignored)                        | Override `output.publicPath` from Webpack config.                                                                               |
+| `relativePath`    | `{Boolean}` | `false`                          | Show relative path instead of absolute path for bundles in JSON Tracker file. Path are relative from path of JSON Tracker file. |
 | `logTime`         | `{Boolean}` | `false`                          | Output `startTime` and `endTime` properties in bundle tracker JSON file.                                                        |
 | `integrity`       | `{Boolean}` | `false`                          | Output `integrity` property for each asset entry.                                                                               |
 | `integrityHashes` | `{Array}`   | `['sha256', 'sha384', 'sha512']` | Cryptographic hash functions used to compute integrity for each asset.                                                          |
-| `indent` | `{Integer}`   | `?` | Format resulting JSON file for better readability.                                                          |
-
-`?` denotes the option is initially not set.
+| `indent`          | `{Integer}` | `undefined`                      | Format resulting JSON file for better readability.                                                                              |

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -33,7 +33,7 @@ declare namespace BundleTrackerPlugin {
      */
     relativePath?: boolean;
     /**
-     * Indent JSON ouput file
+     * Indent JSON output file
      */
     indent?: number;
     /**


### PR DESCRIPTION
While the `indent` option gets a mention in the project's `README`, it is easily overlooked because it is missing from the **Options** table at the end.

This PR properly documents its usage.