### PR TITLE
Output entrypoints and their files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ class BundleTrackerPlugin {
       return;
     }
 
-    const output = { status: 'done', assets: {}, chunks: {} };
+    const output = { status: 'done', assets: {}, chunks: {}, entrypoints: {} };
     each(stats.compilation.assets, (file, assetName) => {
       const fileInfo = {
         name: assetName,
@@ -145,6 +145,12 @@ class BundleTrackerPlugin {
 
       output.chunks[chunkGroup.name] = chunkGroup.getFiles();
     });
+
+    each(Array.from(stats.compilation.entrypoints.values()), (entrypoint) => {
+      if (!entrypoint.isInitial()) return;
+
+      output.entrypoints[entrypoint.name] = entrypoint.getFiles();
+    })
 
     if (this.options.logTime === true) {
       output.startTime = stats.startTime;


### PR DESCRIPTION
This PR is an updated version of the following PR https://github.com/owais/webpack-bundle-tracker/pull/41

This makes possible for django-webpack-loader to automatically include all assets for a particular entrypoint, making it possible to have webpack split vendor code into small chunks and ship the least amount possible of code.