### PR TITLE
Fix typo on compile status

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In case webpack is still compiling, it'll look like,
 
 ```json
 {
-  "status": "compiling"
+  "status": "compile"
 }
 ```
 


### PR DESCRIPTION
When working on https://github.com/owais/django-webpack-loader/pull/232 I noticed the documents states that while webpack is compiling the assets the status is `compiling` but the code is now writing the status as `compile`. Updating the Readme to account this.

Here is the line with the new status code: https://github.com/owais/webpack-bundle-tracker/blob/v1.0.0-alpha.1/lib/index.js#L103
 