### PR TITLE
tests: Fix CompressionPlugin configuration

### DIFF
--- a/tests/base.test.js
+++ b/tests/base.test.js
@@ -534,14 +534,14 @@ describe('BundleTrackerPlugin bases tests', () => {
         plugins: [
           new MiniCssExtractPlugin({ filename: 'css/[name].css' }),
           new CompressionPlugin({
-            filename: '[path].gz[query]',
+            filename: '[path][base].gz[query]',
             test: /\.(js|css)$/,
             threshold: 1,
             minRatio: 1, // Compress all files
             deleteOriginalAssets: false,
           }),
           new CompressionPlugin({
-            filename: '[path].br[query]',
+            filename: '[path][base].br[query]',
             algorithm: 'brotliCompress',
             test: /\.(js|css)$/,
             threshold: 1,


### PR DESCRIPTION
Fixes test failures with messages like `Error: Conflict: Multiple assets emit different content to the same filename js/.gz`.