### PR TITLE
Change outputTrackerFile path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ class BundleTrackerPlugin {
 
     // Set output directories
     this.outputChunkDir = path.resolve(get(compiler.options, 'output.path', process.cwd()));
-    this.outputTrackerFile = path.resolve(path.join(this.options.path, this.options.filename));
+    this.outputTrackerFile = path.resolve(this.options.filename);
     this.outputTrackerDir = path.dirname(this.outputTrackerFile);
 
     return this;


### PR DESCRIPTION
Closes #80

This change makes the package behavior closer to what was on v0.4.3.

On 0.4.3, if we did this on webpack config file:
```js
output: {
    path: path.resolve('./assets/bundles/'),
    filename: "[name]-[hash].js",
    chunkFilename: "[name]-[hash].js"
},
plugins: [
    new BundleTracker({filename: './webpack-stats.json'}),
],
```
The stats file is outputted at the same level of the config file (generally the frontend root).

The same configuration on 1.0.0-alpha.1 has th stats file is outputted as `./assets/bundles/webpack-stats.json`, together with the other assets files. It's possible to manipulate the output by appending leading `../` to the filename or by using the `path` parameter in the `BundleTracker` configuration, however this can get rather confusing.

Tested on https://github.com/django-webpack/django-webpack-loader/pull/271