### PR TITLE
Replaces getting asset path information from asset list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,18 @@ const get = require('lodash.get');
 const each = require('lodash.foreach');
 const stripAnsi = require('strip-ansi');
 
+function getAssetPath(compilation, name) {
+    return path.join(
+      compilation.getPath(compilation.compiler.outputPath),
+      name.split('?')[0]
+    );
+  }
+
+function getSource(compilation, name) {
+  const path = getAssetPath(compilation, name);
+  return fs.readFileSync(path, { encoding: 'utf-8' });
+}
+
 class BundleTrackerPlugin {
   /**
    * Track assets file location per bundle
@@ -126,11 +138,11 @@ class BundleTrackerPlugin {
     each(stats.compilation.assets, (file, assetName) => {
       const fileInfo = {
         name: assetName,
-        path: file.existsAt,
+        path: getAssetPath(stats.compilation, assetName),
       };
 
       if (this.options.integrity === true) {
-        fileInfo.integrity = this._computeIntegrity(file.source());
+        fileInfo.integrity = this._computeIntegrity(getSource(stats.compilation, assetName));
       }
 
       if (this.options.publicPath) {


### PR DESCRIPTION
From https://webpack.js.org/blog/2020-10-10-webpack-5-release/#sizeonlysource-after-emit

This was breaking `relativePath: true` and `integrity: true` plugin parameters.

Fixes #78 