### PR TITLE
Fix corruption after hot updates due to misuse of lodash.merge

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ class BundleTrackerPlugin {
     /** @type {Contents} */
     this.contents = {
       status: 'initialization',
+      assets: {},
       chunks: {},
     };
     this.name = 'BundleTrackerPlugin';
@@ -77,7 +78,7 @@ class BundleTrackerPlugin {
    * Write bundle tracker stats file
    *
    * @param {Compiler} compiler
-   * @param {Contents} contents
+   * @param {Partial<Contents>} contents
    */
   _writeOutput(compiler, contents) {
     merge(this.contents, contents);
@@ -131,6 +132,7 @@ class BundleTrackerPlugin {
       return;
     }
 
+    /** @type {Contents} */
     const output = { status: 'done', assets: {}, chunks: {} };
     each(stats.compilation.assets, (file, assetName) => {
       const fileInfo = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 // @ts-check
 /** @typedef {import("lodash.defaults")} defaults */
-/** @typedef {import("lodash.merge")} merge */
+/** @typedef {import("lodash.assign")} assign */
 /** @typedef {import("lodash.get")} get */
 /** @typedef {import("webpack").Compiler} Compiler */
 /** @typedef {import("webpack").Stats} Stats */
@@ -15,7 +15,7 @@ const fs = require('fs');
 const crypto = require('crypto');
 
 const defaults = require('lodash.defaults');
-const merge = require('lodash.merge');
+const assign = require('lodash.assign');
 const get = require('lodash.get');
 const each = require('lodash.foreach');
 const stripAnsi = require('strip-ansi');
@@ -81,7 +81,10 @@ class BundleTrackerPlugin {
    * @param {Partial<Contents>} contents
    */
   _writeOutput(compiler, contents) {
-    merge(this.contents, contents);
+    assign(this.contents, contents, {
+      assets: assign(this.contents.assets, contents.assets),
+      chunks: assign(this.contents.chunks, contents.chunks),
+    });
 
     if (this.options.publicPath) {
       this.contents.publicPath = this.options.publicPath;

--- a/package.json
+++ b/package.json
@@ -36,15 +36,13 @@
     "lodash.defaults": "^4.2.0",
     "lodash.foreach": "^4.5.0",
     "lodash.get": "^4.4.2",
-    "lodash.merge": "^4.6.2",
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {
     "@types/lodash.assign": "^4.2.6",
+    "@types/lodash.defaults": "^4.2.6",
     "@types/lodash.foreach": "^4.5.6",
     "@types/lodash.get": "^4.4.6",
-    "@types/lodash.merge": "^4.6.6",
-    "@types/lodash.defaults": "^4.2.6",
     "@types/mkdirp": "^1.0.1",
     "@types/node": "^13.13.52",
     "@types/webpack": "^4.41.28",

--- a/tests/base.test.js
+++ b/tests/base.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 'use strict';
 
+const fs = require('fs');
 const zlib = require('zlib');
 const path = require('path');
 const rimraf = require('rimraf');
@@ -633,6 +634,72 @@ describe('BundleTrackerPlugin bases tests', () => {
       done,
       expectErrors,
       expectWarnings,
+    );
+  });
+
+  it('correctly merges chunks after multiple runs', done => {
+    fs.writeFileSync(
+      path.join(OUTPUT_DIR, 'app1.js'),
+      `require(${JSON.stringify(path.resolve(__dirname, 'fixtures', 'commons.js'))});`,
+    );
+    const compiler = webpack(
+      {
+        context: __dirname,
+        entry: {
+          app1: path.join(OUTPUT_DIR, 'app1.js'),
+          app2: path.resolve(__dirname, 'fixtures', 'app2.js'),
+        },
+        output: {
+          path: path.join(OUTPUT_DIR, 'js'),
+          filename: 'js/[name].js',
+          publicPath: 'http://localhost:3000/assets/',
+        },
+        optimization: {
+          splitChunks: {
+            cacheGroups: {
+              vendors: {
+                name: 'vendors',
+                test: /[\\/]node_modules[\\/]/,
+                priority: -10,
+                chunks: 'initial',
+              },
+              commons: {
+                name: 'commons',
+                test: /[\\/]?commons/,
+                enforce: true,
+                priority: -20,
+                chunks: 'all',
+                reuseExistingChunk: true,
+              },
+              default: {
+                name: 'shared',
+                reuseExistingChunk: true,
+              },
+            },
+          },
+        },
+        plugins: [
+          new BundleTrackerPlugin({
+            path: OUTPUT_DIR,
+            relativePath: true,
+            includeParents: true,
+            filename: path.join(OUTPUT_DIR, 'webpack-stats.json'),
+          }),
+        ],
+      },
+      () => {
+        // Edit app1.js and rerun the compilation
+        fs.writeFileSync(path.join(OUTPUT_DIR, 'app1.js'), '');
+        compiler.run(() => {
+          const trackerStatsContent = fs.readFileSync(path.join(OUTPUT_DIR, 'webpack-stats.json'), 'utf8');
+          const trackerStats = JSON.parse(trackerStatsContent);
+          expect(trackerStats.chunks).toMatchObject({
+            app1: ['js/app1.js'],
+            app2: ['js/commons.js', 'js/app2.js'],
+          });
+          done();
+        });
+      },
     );
   });
 });

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -61,16 +61,27 @@ declare namespace BundleTrackerPlugin {
      */
     message?: string;
     /**
+     * File information
+     */
+    assets: {
+      [name: string]: {
+        name: string;
+        integrity?: string;
+        publicPath?: string;
+        path: string;
+      };
+    };
+    /**
      * List of chunks builded
      */
-    chunks?: {
+    chunks: {
       [name: string]: [
         {
           name: string;
           publicPath?: string;
           path: string;
-        }
-      ]
+        },
+      ];
     };
     /**
      * Public path of chunks


### PR DESCRIPTION
`lodash.merge` has the following undesired behavior on arrays:

```js
> chunks = { main: ['a', 'b', 'c', 'd', 'e'] }
{ main: [ 'a', 'b', 'c', 'd', 'e' ] }
> merge(chunks, { main: ['foo', 'bar'] })
{ main: [ 'foo', 'bar', 'c', 'd', 'e' ] }
```

Instead of using `lodash.merge` (#98), specify exactly which objects need to be combined using `lodash.assign`.

Cc @TomekStaszkiewicz @joaopslins