### PR TITLE
using getter to access error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -129,7 +129,7 @@ class BundleTrackerPlugin {
       this._writeOutput(compiler, {
         status: 'error',
         error: get(error, 'name', 'unknown-error'),
-        message: stripAnsi(error['message']),
+        message: stripAnsi(get(error, 'message')),
       });
 
       return;


### PR DESCRIPTION
https://github.com/vinojv/webpack-bundle-tracker/blob/master/lib/index.js#L132 breaks in circleci since error is undefined.
<img width="1318" alt="Screenshot 2021-08-05 at 12 47 50 PM" src="https://user-images.githubusercontent.com/7531234/128308112-d8342588-4174-4963-abe2-b1877caf060c.png">

you can replicate the error by using worker-loader and webworker
