### PR TITLE
Fix reporting errors from child compilations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,13 @@ class BundleTrackerPlugin {
    */
   _handleDone(compiler, stats) {
     if (stats.hasErrors()) {
-      const error = stats.compilation.errors[0];
+      const findError = compilation => {
+        if (compilation.errors.length > 0) {
+          return compilation.errors[0];
+        }
+        return compilation.children.find(child => findError(child));
+      };
+      const error = findError(stats.compilation);
       this._writeOutput(compiler, {
         status: 'error',
         error: get(error, 'name', 'unknown-error'),


### PR DESCRIPTION
Replaces #103 to fix error reporting when the error happens in child compilations.

We should recursively traverse child compilations just like the `hasErrors` method that we're using does:
https://github.com/webpack/webpack/blob/c181294865dca01b28e6e316636fef5f2aad4eb6/lib/Stats.js#L45