### PR TITLE
fix: use path option for tracker output file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,8 +86,9 @@ class BundleTrackerPlugin {
 
     // Set output directories
     this.outputChunkDir = path.resolve(get(compiler.options, 'output.path', process.cwd()));
+    // @ts-ignore: TS2345 this.options.path can't be undefined here because we set a default value above
     // @ts-ignore: TS2345 this.options.filename can't be undefined here because we set a default value above
-    this.outputTrackerFile = path.resolve(this.options.filename);
+    this.outputTrackerFile = path.resolve(path.join(this.options.path, this.options.filename));
     this.outputTrackerDir = path.dirname(this.outputTrackerFile);
 
     return this;


### PR DESCRIPTION
revert 51dfab5759c2b72d68cd5728b56c64e11e992f41
fix #108