### PR TITLE
Add `typings.d.ts` to packaged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "author": "Owais Lone",
   "main": "lib/index.js",
   "files": [
-    "lib/"
+    "lib/",
+    "typings.d.ts"
   ],
   "types": "typings.d.ts",
   "scripts": {


### PR DESCRIPTION
Hi,

Looks like `typings.d.ts` is missing from `3.0.0`. This caused issues in our project (which imports this package from TypeScript), so I added it to `files` in `package.json`.