### PR TITLE
Add assets source filenames

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,6 +192,12 @@ class BundleTrackerPlugin {
         fileInfo.path = path.relative(this.outputChunkDir, fileInfo.path);
       }
 
+      // @ts-ignore: TS2339: Property 'assetsInfo' does not exist on type 'Compilation'.
+      if (stats.compilation.assetsInfo) {
+        // @ts-ignore: TS2339: Property 'assetsInfo' does not exist on type 'Compilation'.
+        fileInfo.sourceFilename = stats.compilation.assetsInfo.get(assetName).sourceFilename;
+      }
+
       output.assets[assetName] = fileInfo;
     });
     each(stats.compilation.chunkGroups, chunkGroup => {

--- a/tests/fixtures/appWithAssetResources.js
+++ b/tests/fixtures/appWithAssetResources.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const common = require('./commons');
+
+require('./assets/resources/test.txt')
+
+require(["./shared"], function(shared) {
+	shared("This is app with asset resources");
+});

--- a/tests/fixtures/assets/resources/test.txt
+++ b/tests/fixtures/assets/resources/test.txt
@@ -1,0 +1,1 @@
+Hello world

--- a/tests/webpack5.test.js
+++ b/tests/webpack5.test.js
@@ -638,6 +638,53 @@ describe('BundleTrackerPlugin bases tests', () => {
     );
   });
 
+  it("shows original asset's filepath", done => {
+    const expectErrors = null;
+    const expectWarnings = getWebpack5WarningMessage();
+
+    testPlugin(
+      webpack5,
+      {
+        context: __dirname,
+        entry: {
+          appWithAssetResources: path.resolve(__dirname, 'fixtures', 'appWithAssetResources.js'),
+        },
+        output: {
+          assetModuleFilename: 'assets/[name]-[contenthash][ext]',
+          path: OUTPUT_DIR,
+          filename: 'js/[name].js',
+          publicPath: 'http://localhost:3000/assets/',
+        },
+        module: {
+          rules: [{ test: /\.txt$/, type: 'asset/resource' }],
+        },
+        plugins: [
+          new BundleTrackerPlugin({
+            path: OUTPUT_DIR,
+            relativePath: true,
+            includeParents: true,
+            filename: 'webpack-stats.json',
+          }),
+        ],
+      },
+      {
+        status: 'done',
+        assets: {
+          'assets/test-bbf3c94e2a3948c98900.txt': {
+            name: 'assets/test-bbf3c94e2a3948c98900.txt',
+            path: 'assets/test-bbf3c94e2a3948c98900.txt',
+            publicPath: 'http://localhost:3000/assets/assets/test-bbf3c94e2a3948c98900.txt',
+            sourceFilename: 'fixtures/assets/resources/test.txt',
+          },
+        },
+      },
+      'webpack-stats.json',
+      done,
+      expectErrors,
+      expectWarnings,
+    );
+  });
+
   it('correctly merges chunks after multiple runs', done => {
     fs.writeFileSync(
       path.join(OUTPUT_DIR, 'app1.js'),

--- a/tests/webpack5.test.js
+++ b/tests/webpack5.test.js
@@ -810,7 +810,7 @@ describe('BundleTrackerPlugin bases tests', () => {
         const assetsKeys = toPairs(stats.assets).map(pair => pair[0]);
         const chunksKeys = toPairs(stats.chunks).map(pair => pair[0]);
 
-        expect(assetsKeys).toEqual(['css/appA.css', 'js/862.js', 'js/appA.js', 'js/appZ.js', 'js/commons.js']);
+        expect(assetsKeys).toEqual(['css/appA.css', 'js/75.js', 'js/appA.js', 'js/appZ.js', 'js/commons.js']);
         expect(chunksKeys).toEqual(['appA', 'appZ']);
 
         done();


### PR DESCRIPTION
Add `sourceFilename` field

Asset resources in `webpack-stats.json` file will look like,

```json
"assets": {
  "assets/test-bbf3c94e2a3948c98900.txt": {
    "name": "assets/test-bbf3c94e2a3948c98900.txt",
    "path": "/home/user/project-root/assets/test-bbf3c94e2a3948c98900.txt",
    "publicPath": "http://localhost:3000/assets/test-bbf3c94e2a3948c98900.txt",
    "sourceFilename": "src/test.txt"
  }
}
```

Related to https://github.com/django-webpack/django-webpack-loader/issues/343